### PR TITLE
Agrega ejemplos de mutex y semáforos

### DIFF
--- a/freertos-labs/03_mutex_demo/FreeRTOSConfig.h
+++ b/freertos-labs/03_mutex_demo/FreeRTOSConfig.h
@@ -1,0 +1,56 @@
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+#include <stdint.h>
+
+/*-----------------------------------------------------------
+ * Configuración del kernel
+ *----------------------------------------------------------*/
+
+#define configUSE_PREEMPTION                    1
+#define configUSE_IDLE_HOOK                     0
+#define configUSE_TICK_HOOK                     0
+#define configCPU_CLOCK_HZ                      (72000000UL)
+#define configTICK_RATE_HZ                      (1000)
+#define configMAX_PRIORITIES                    5
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY    (5 << 4)
+#define configKERNEL_INTERRUPT_PRIORITY         (255)
+#define configMINIMAL_STACK_SIZE                (128)
+#define configTOTAL_HEAP_SIZE                   (8 * 1024)
+#define configMAX_TASK_NAME_LEN                 16
+#define configUSE_16_BIT_TICKS                  0
+#define configIDLE_SHOULD_YIELD                 1
+
+/*-----------------------------------------------------------
+ * Configuración de sincronización y recursos
+ *----------------------------------------------------------*/
+
+#define configUSE_MUTEXES                       1
+#define configUSE_RECURSIVE_MUTEXES             1
+#define configUSE_COUNTING_SEMAPHORES           1
+#define configQUEUE_REGISTRY_SIZE               8
+
+/*-----------------------------------------------------------
+ * Inclusión de funciones de la API
+ *----------------------------------------------------------*/
+
+#define INCLUDE_vTaskDelay                      1
+#define INCLUDE_vTaskDelayUntil                 1
+#define INCLUDE_vTaskDelete                     1
+#define INCLUDE_vTaskSuspend                    1
+#define INCLUDE_vTaskPrioritySet                1
+#define INCLUDE_uxTaskPriorityGet               1
+#define INCLUDE_xTaskGetSchedulerState          1
+
+/*-----------------------------------------------------------
+ * Seguridad y depuración
+ *----------------------------------------------------------*/
+
+#define configASSERT(x) if((x) == 0) { taskDISABLE_INTERRUPTS(); for(;;); }
+
+/* Redirect FreeRTOS port interrupts. */
+#define vPortSVCHandler     sv_call_handler
+#define xPortPendSVHandler  pend_sv_handler
+#define xPortSysTickHandler sys_tick_handler
+
+#endif /* FREERTOS_CONFIG_H */

--- a/freertos-labs/03_mutex_demo/Makefile
+++ b/freertos-labs/03_mutex_demo/Makefile
@@ -1,0 +1,96 @@
+# Proyecto bare-metal STM32F103C8T6 con libopencm3
+PROJECT = main
+TARGET = $(PROJECT).elf
+BUILD_DIR = bin
+
+# Rutas base
+COMMON        	= ../../common
+LIBOPENCM3_DIR 	= ../../libopencm3
+FREERTOS_DIR 	= ../../freertos
+
+
+# Includes
+INCLUDES  = -I$(LIBOPENCM3_DIR)/include
+INCLUDES += -I$(COMMON)
+
+INCLUDES += -I$(FREERTOS_DIR)
+INCLUDES += -I$(FREERTOS_DIR)/include
+INCLUDES += -I$(FREERTOS_DIR)/portable/GCC/ARM_CM3
+
+INCLUDES += -I./
+
+# Micro objetivo
+MCU     = cortex-m3
+CDEFS   = -DSTM32F1
+
+# Compilador
+CC      = arm-none-eabi-gcc
+OBJCOPY = arm-none-eabi-objcopy
+CFLAGS  = -mcpu=$(MCU) -mthumb -Wall -O0 -g $(INCLUDES) $(CDEFS) -nostdlib
+
+# Linker
+LDSCRIPT = $(COMMON)/linker.ld
+LDFLAGS  =-nostartfiles -Wl,--gc-sections -Wl,-Map=$(BUILD_DIR)/$(PROJECT).map  -T$(LDSCRIPT) 
+LDLIBS   = -L$(LIBOPENCM3_DIR)/lib -lopencm3_stm32f1 -lc -lgcc -lnosys
+
+# Fuentes
+FREERTOS_SRC = \
+    $(FREERTOS_DIR)/list.c \
+    $(FREERTOS_DIR)/queue.c \
+    $(FREERTOS_DIR)/tasks.c \
+    $(FREERTOS_DIR)/heap_4.c \
+    $(FREERTOS_DIR)/portable/GCC/ARM_CM3/port.c 
+
+SRC = main.c $(FREERTOS_SRC)
+
+OBJ = $(patsubst %.c, $(BUILD_DIR)/%.o, $(notdir $(SRC)))
+
+# Decimos a make dónde buscar los .c
+vpath %.c $(dir $(SRC))
+
+# Meta-targets
+.PHONY: all clean flash openocd gdb size help
+
+all: $(BUILD_DIR)/$(TARGET)
+
+$(BUILD_DIR)/$(TARGET): $(OBJ) $(LIBOPENCM3_DIR)/lib/libopencm3_stm32f1.a
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(LDLIBS)
+	$(OBJCOPY) -O ihex   $@ $(BUILD_DIR)/$(PROJECT).hex
+	$(OBJCOPY) -O binary $@ $(BUILD_DIR)/$(PROJECT).bin
+
+# Compilación de fuentes
+$(BUILD_DIR)/%.o: %.c
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+# Compilar libopencm3 si falta
+$(LIBOPENCM3_DIR)/lib/libopencm3_stm32f1.a:
+	$(MAKE) -C $(LIBOPENCM3_DIR)
+
+# Flash con OpenOCD
+flash: $(BUILD_DIR)/$(TARGET)
+	openocd -f interface/stlink.cfg -f target/stm32f1x.cfg -c "program $< verify reset exit"
+
+# Sesiones útiles
+openocd:
+	openocd -f interface/stlink.cfg -f target/stm32f1x.cfg
+
+gdb: $(BUILD_DIR)/$(TARGET)
+	gdb-multiarch $< -ex "target remote localhost:3333"
+
+size: $(BUILD_DIR)/$(TARGET)
+	arm-none-eabi-size $<
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+help:
+	@echo "Comandos disponibles:"
+	@echo "  make           → Compila el proyecto"
+	@echo "  make flash     → Flashea el binario vía OpenOCD"
+	@echo "  make gdb       → Conecta GDB al target"
+	@echo "  make openocd   → Lanza el servidor OpenOCD"
+	@echo "  make size      → Muestra el uso de memoria"
+	@echo "  make clean     → Limpia la carpeta bin/"
+	@echo "  make help      → Muestra esta ayuda"
+	@echo "  make all       → Compila el proyecto (alias de make)"

--- a/freertos-labs/03_mutex_demo/README.md
+++ b/freertos-labs/03_mutex_demo/README.md
@@ -1,0 +1,13 @@
+# Ejemplo de Mutex con FreeRTOS
+
+Este proyecto muestra el uso básico de un **mutex** para proteger el acceso al
+puerto serie en la placa **Blue Pill**. Dos tareas intentan enviar mensajes por
+UART; el mutex evita que los textos se mezclen. Además se parpadea el LED
+onboard como indicación de que el sistema está activo.
+
+## Compilación y ejecución
+
+```bash
+make
+make flash
+```

--- a/freertos-labs/03_mutex_demo/main.c
+++ b/freertos-labs/03_mutex_demo/main.c
@@ -1,0 +1,79 @@
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/usart.h>
+
+#include "FreeRTOS.h"
+#include "task.h"
+#include "semphr.h"
+
+#define LED_PORT GPIOC
+#define LED_PIN  GPIO13
+#define USART    USART1
+
+static SemaphoreHandle_t serial_mutex;
+
+static void gpio_setup(void) {
+    rcc_periph_clock_enable(RCC_GPIOC);
+    gpio_set_mode(LED_PORT, GPIO_MODE_OUTPUT_2_MHZ,
+                  GPIO_CNF_OUTPUT_PUSHPULL, LED_PIN);
+    gpio_clear(LED_PORT, LED_PIN);
+}
+
+static void usart_setup(void) {
+    rcc_periph_clock_enable(RCC_GPIOA);
+    rcc_periph_clock_enable(RCC_USART1);
+
+    gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_50_MHZ,
+                  GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, GPIO9);  // TX
+    gpio_set_mode(GPIOA, GPIO_MODE_INPUT,
+                  GPIO_CNF_INPUT_PULL_UPDOWN, GPIO10);    // RX
+    gpio_set(GPIOA, GPIO10); // pull-up
+
+    usart_set_baudrate(USART, 9600);
+    usart_set_databits(USART, 8);
+    usart_set_stopbits(USART, USART_STOPBITS_1);
+    usart_set_mode(USART, USART_MODE_TX_RX);
+    usart_set_parity(USART, USART_PARITY_NONE);
+    usart_set_flow_control(USART, USART_FLOWCONTROL_NONE);
+    usart_enable(USART);
+}
+
+static void send_string(const char *s) {
+    while (*s)
+        usart_send_blocking(USART, *s++);
+}
+
+static void writer_task(void *args) {
+    const char *msg = (const char *)args;
+    while (1) {
+        if (xSemaphoreTake(serial_mutex, portMAX_DELAY) == pdPASS) {
+            send_string(msg);
+            xSemaphoreGive(serial_mutex);
+        }
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+}
+
+static void heartbeat_task(void *args) {
+    (void)args;
+    while (1) {
+        gpio_toggle(LED_PORT, LED_PIN);
+        vTaskDelay(pdMS_TO_TICKS(500));
+    }
+}
+
+int main(void) {
+    rcc_clock_setup_pll(&rcc_hse_configs[RCC_CLOCK_HSE8_72MHZ]);
+    gpio_setup();
+    usart_setup();
+
+    serial_mutex = xSemaphoreCreateMutex();
+    configASSERT(serial_mutex != NULL);
+
+    xTaskCreate(writer_task, "A", 128, "Task A -> uso de mutex\r\n", 1, NULL);
+    xTaskCreate(writer_task, "B", 128, "Task B -> recurso compartido\r\n", 1, NULL);
+    xTaskCreate(heartbeat_task, "LED", 128, NULL, 1, NULL);
+
+    vTaskStartScheduler();
+    while (1);
+}

--- a/freertos-labs/04_semaphore_demo/FreeRTOSConfig.h
+++ b/freertos-labs/04_semaphore_demo/FreeRTOSConfig.h
@@ -1,0 +1,56 @@
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+#include <stdint.h>
+
+/*-----------------------------------------------------------
+ * Configuración del kernel
+ *----------------------------------------------------------*/
+
+#define configUSE_PREEMPTION                    1
+#define configUSE_IDLE_HOOK                     0
+#define configUSE_TICK_HOOK                     0
+#define configCPU_CLOCK_HZ                      (72000000UL)
+#define configTICK_RATE_HZ                      (1000)
+#define configMAX_PRIORITIES                    5
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY    (5 << 4)
+#define configKERNEL_INTERRUPT_PRIORITY         (255)
+#define configMINIMAL_STACK_SIZE                (128)
+#define configTOTAL_HEAP_SIZE                   (8 * 1024)
+#define configMAX_TASK_NAME_LEN                 16
+#define configUSE_16_BIT_TICKS                  0
+#define configIDLE_SHOULD_YIELD                 1
+
+/*-----------------------------------------------------------
+ * Configuración de sincronización y recursos
+ *----------------------------------------------------------*/
+
+#define configUSE_MUTEXES                       1
+#define configUSE_RECURSIVE_MUTEXES             1
+#define configUSE_COUNTING_SEMAPHORES           1
+#define configQUEUE_REGISTRY_SIZE               8
+
+/*-----------------------------------------------------------
+ * Inclusión de funciones de la API
+ *----------------------------------------------------------*/
+
+#define INCLUDE_vTaskDelay                      1
+#define INCLUDE_vTaskDelayUntil                 1
+#define INCLUDE_vTaskDelete                     1
+#define INCLUDE_vTaskSuspend                    1
+#define INCLUDE_vTaskPrioritySet                1
+#define INCLUDE_uxTaskPriorityGet               1
+#define INCLUDE_xTaskGetSchedulerState          1
+
+/*-----------------------------------------------------------
+ * Seguridad y depuración
+ *----------------------------------------------------------*/
+
+#define configASSERT(x) if((x) == 0) { taskDISABLE_INTERRUPTS(); for(;;); }
+
+/* Redirect FreeRTOS port interrupts. */
+#define vPortSVCHandler     sv_call_handler
+#define xPortPendSVHandler  pend_sv_handler
+#define xPortSysTickHandler sys_tick_handler
+
+#endif /* FREERTOS_CONFIG_H */

--- a/freertos-labs/04_semaphore_demo/Makefile
+++ b/freertos-labs/04_semaphore_demo/Makefile
@@ -1,0 +1,96 @@
+# Proyecto bare-metal STM32F103C8T6 con libopencm3
+PROJECT = main
+TARGET = $(PROJECT).elf
+BUILD_DIR = bin
+
+# Rutas base
+COMMON        	= ../../common
+LIBOPENCM3_DIR 	= ../../libopencm3
+FREERTOS_DIR 	= ../../freertos
+
+
+# Includes
+INCLUDES  = -I$(LIBOPENCM3_DIR)/include
+INCLUDES += -I$(COMMON)
+
+INCLUDES += -I$(FREERTOS_DIR)
+INCLUDES += -I$(FREERTOS_DIR)/include
+INCLUDES += -I$(FREERTOS_DIR)/portable/GCC/ARM_CM3
+
+INCLUDES += -I./
+
+# Micro objetivo
+MCU     = cortex-m3
+CDEFS   = -DSTM32F1
+
+# Compilador
+CC      = arm-none-eabi-gcc
+OBJCOPY = arm-none-eabi-objcopy
+CFLAGS  = -mcpu=$(MCU) -mthumb -Wall -O0 -g $(INCLUDES) $(CDEFS) -nostdlib
+
+# Linker
+LDSCRIPT = $(COMMON)/linker.ld
+LDFLAGS  =-nostartfiles -Wl,--gc-sections -Wl,-Map=$(BUILD_DIR)/$(PROJECT).map  -T$(LDSCRIPT) 
+LDLIBS   = -L$(LIBOPENCM3_DIR)/lib -lopencm3_stm32f1 -lc -lgcc -lnosys
+
+# Fuentes
+FREERTOS_SRC = \
+    $(FREERTOS_DIR)/list.c \
+    $(FREERTOS_DIR)/queue.c \
+    $(FREERTOS_DIR)/tasks.c \
+    $(FREERTOS_DIR)/heap_4.c \
+    $(FREERTOS_DIR)/portable/GCC/ARM_CM3/port.c 
+
+SRC = main.c $(FREERTOS_SRC)
+
+OBJ = $(patsubst %.c, $(BUILD_DIR)/%.o, $(notdir $(SRC)))
+
+# Decimos a make dónde buscar los .c
+vpath %.c $(dir $(SRC))
+
+# Meta-targets
+.PHONY: all clean flash openocd gdb size help
+
+all: $(BUILD_DIR)/$(TARGET)
+
+$(BUILD_DIR)/$(TARGET): $(OBJ) $(LIBOPENCM3_DIR)/lib/libopencm3_stm32f1.a
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(LDLIBS)
+	$(OBJCOPY) -O ihex   $@ $(BUILD_DIR)/$(PROJECT).hex
+	$(OBJCOPY) -O binary $@ $(BUILD_DIR)/$(PROJECT).bin
+
+# Compilación de fuentes
+$(BUILD_DIR)/%.o: %.c
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+# Compilar libopencm3 si falta
+$(LIBOPENCM3_DIR)/lib/libopencm3_stm32f1.a:
+	$(MAKE) -C $(LIBOPENCM3_DIR)
+
+# Flash con OpenOCD
+flash: $(BUILD_DIR)/$(TARGET)
+	openocd -f interface/stlink.cfg -f target/stm32f1x.cfg -c "program $< verify reset exit"
+
+# Sesiones útiles
+openocd:
+	openocd -f interface/stlink.cfg -f target/stm32f1x.cfg
+
+gdb: $(BUILD_DIR)/$(TARGET)
+	gdb-multiarch $< -ex "target remote localhost:3333"
+
+size: $(BUILD_DIR)/$(TARGET)
+	arm-none-eabi-size $<
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+help:
+	@echo "Comandos disponibles:"
+	@echo "  make           → Compila el proyecto"
+	@echo "  make flash     → Flashea el binario vía OpenOCD"
+	@echo "  make gdb       → Conecta GDB al target"
+	@echo "  make openocd   → Lanza el servidor OpenOCD"
+	@echo "  make size      → Muestra el uso de memoria"
+	@echo "  make clean     → Limpia la carpeta bin/"
+	@echo "  make help      → Muestra esta ayuda"
+	@echo "  make all       → Compila el proyecto (alias de make)"

--- a/freertos-labs/04_semaphore_demo/README.md
+++ b/freertos-labs/04_semaphore_demo/README.md
@@ -1,0 +1,14 @@
+# Ejemplo de Semáforo con FreeRTOS
+
+En este ejemplo se utiliza un **semáforo binario** para sincronizar la llegada de
+caracteres por UART con una tarea de procesamiento. El ISR de la UART entrega el
+semáforo cada vez que se recibe un byte. La tarea que espera el semáforo reenvía
+el carácter recibido y, si éste es `t`, conmuta el LED integrado de la placa
+**Blue Pill**.
+
+## Compilación y ejecución
+
+```bash
+make
+make flash
+```

--- a/freertos-labs/04_semaphore_demo/main.c
+++ b/freertos-labs/04_semaphore_demo/main.c
@@ -1,0 +1,89 @@
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/usart.h>
+#include <libopencm3/cm3/nvic.h>
+
+#include "FreeRTOS.h"
+#include "task.h"
+#include "semphr.h"
+
+#define LED_PORT GPIOC
+#define LED_PIN  GPIO13
+#define USART    USART1
+
+static SemaphoreHandle_t rx_sem;
+static volatile char rx_char;
+
+static void gpio_setup(void) {
+    rcc_periph_clock_enable(RCC_GPIOC);
+    gpio_set_mode(LED_PORT, GPIO_MODE_OUTPUT_2_MHZ,
+                  GPIO_CNF_OUTPUT_PUSHPULL, LED_PIN);
+    gpio_clear(LED_PORT, LED_PIN);
+}
+
+static void usart_setup(void) {
+    rcc_periph_clock_enable(RCC_GPIOA);
+    rcc_periph_clock_enable(RCC_USART1);
+
+    gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_50_MHZ,
+                  GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, GPIO9);  // TX
+    gpio_set_mode(GPIOA, GPIO_MODE_INPUT,
+                  GPIO_CNF_INPUT_PULL_UPDOWN, GPIO10);    // RX
+    gpio_set(GPIOA, GPIO10); // pull-up
+
+    usart_set_baudrate(USART, 9600);
+    usart_set_databits(USART, 8);
+    usart_set_stopbits(USART, USART_STOPBITS_1);
+    usart_set_mode(USART, USART_MODE_TX_RX);
+    usart_set_parity(USART, USART_PARITY_NONE);
+    usart_set_flow_control(USART, USART_FLOWCONTROL_NONE);
+    usart_enable(USART);
+
+    nvic_set_priority(NVIC_USART1_IRQ, 0x60); // compatible con FreeRTOS
+    nvic_enable_irq(NVIC_USART1_IRQ);
+    usart_enable_rx_interrupt(USART);
+}
+
+void usart1_isr(void) {
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    if (usart_get_flag(USART, USART_SR_RXNE)) {
+        rx_char = usart_recv(USART);
+        xSemaphoreGiveFromISR(rx_sem, &xHigherPriorityTaskWoken);
+    }
+    portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+}
+
+static void echo_task(void *args) {
+    (void)args;
+    while (1) {
+        xSemaphoreTake(rx_sem, portMAX_DELAY);
+        usart_send_blocking(USART, rx_char);
+        usart_send_blocking(USART, '\r');
+        usart_send_blocking(USART, '\n');
+        if (rx_char == 't' || rx_char == 'T')
+            gpio_toggle(LED_PORT, LED_PIN);
+    }
+}
+
+static void heartbeat_task(void *args) {
+    (void)args;
+    while (1) {
+        gpio_toggle(LED_PORT, LED_PIN);
+        vTaskDelay(pdMS_TO_TICKS(500));
+    }
+}
+
+int main(void) {
+    rcc_clock_setup_pll(&rcc_hse_configs[RCC_CLOCK_HSE8_72MHZ]);
+    gpio_setup();
+    usart_setup();
+
+    rx_sem = xSemaphoreCreateBinary();
+    configASSERT(rx_sem != NULL);
+
+    xTaskCreate(echo_task, "Echo", 128, NULL, 1, NULL);
+    xTaskCreate(heartbeat_task, "Blink", 128, NULL, 1, NULL);
+
+    vTaskStartScheduler();
+    while (1);
+}


### PR DESCRIPTION
## Summary
- se añadieron los proyectos `03_mutex_demo` y `04_semaphore_demo` en `freertos-labs`
- cada proyecto incluye `FreeRTOSConfig.h`, `Makefile`, `main.c` y un `README.md`
- `03_mutex_demo` muestra cómo proteger el puerto serie con un mutex
- `04_semaphore_demo` ejemplifica el uso de un semáforo binario para eventos de la UART

## Testing
- `make -C freertos-labs/03_mutex_demo` *(falla: no se encuentran dependencias)*
- `make -C freertos-labs/04_semaphore_demo` *(falla: no se encuentran dependencias)*

------
https://chatgpt.com/codex/tasks/task_e_6840a2411da48323b75b97a5adec36ee