### PR TITLE
Fix timer frequency formula for TIM2

### DIFF
--- a/labs/04_entrada_boton/04_temporizado_por_timer/README.md
+++ b/labs/04_entrada_boton/04_temporizado_por_timer/README.md
@@ -38,7 +38,9 @@ Se configura **TIM2** para interrumpir cada 1 ms:
 Para obtener el valor correcto del período, se utiliza:
 
 ```c
-#define TIMER_PERIOD (rcc_ahb_frequency / TIMER_PRESCALER / TIMER_FREQUENCY_HZ)
+#define TIMER_CLOCK_HZ ((rcc_apb1_frequency == rcc_ahb_frequency) ? \
+                        rcc_apb1_frequency : rcc_apb1_frequency * 2)
+#define TIMER_PERIOD   (TIMER_CLOCK_HZ / TIMER_PRESCALER / TIMER_FREQUENCY_HZ)
 ```
 
 Esto permite adaptar el código a distintas configuraciones de reloj sin asumir una frecuencia fija.

--- a/labs/04_entrada_boton/04_temporizado_por_timer/main.c
+++ b/labs/04_entrada_boton/04_temporizado_por_timer/main.c
@@ -9,14 +9,17 @@
 #define UMBRAL_ESTABILIDAD     20       // 20 lecturas estables → se requieren 20 ms de estabilidad
 
 // ⚠️ Nota sobre el cálculo del período del timer:
-// En lugar de asumir una frecuencia fija como 72 MHz, utilizamos la variable
-// global `rcc_ahb_frequency`, provista por libopencm3. Esta variable se
-// actualiza automáticamente cuando se llama a `rcc_clock_setup_pll(...)`.
-// Equivale conceptualmente a `SystemCoreClock` en CMSIS.
+// En lugar de asumir una frecuencia fija como 72 MHz, consultamos las
+// variables `rcc_apb1_frequency` y `rcc_ahb_frequency` provistas por
+// libopencm3. Estas se actualizan automáticamente cuando se llama a
+// `rcc_clock_setup_pll(...)`.
 //
-// De este modo, el valor de TIMER_PERIOD se adapta a la configuración activa
-// del reloj del sistema, sin necesidad de hardcodear valores.
-#define TIMER_PERIOD  (rcc_ahb_frequency / TIMER_PRESCALER / TIMER_FREQUENCY_HZ)
+// Así, `TIMER_CLOCK_HZ` refleja la frecuencia real que alimenta a TIM2
+// (doblada si el bus APB1 tiene prescaler distinto de 1) y `TIMER_PERIOD`
+// se ajusta automáticamente al reloj del sistema sin valores fijos.
+#define TIMER_CLOCK_HZ  ((rcc_apb1_frequency == rcc_ahb_frequency) ? \
+                         rcc_apb1_frequency : rcc_apb1_frequency * 2)
+#define TIMER_PERIOD  (TIMER_CLOCK_HZ / TIMER_PRESCALER / TIMER_FREQUENCY_HZ)
 
 // Variables para gestionar la lógica del botón y el LED
 volatile int contador_estabilidad   = 0;

--- a/labs/04_entrada_boton/05_interrupcion_exti/README.md
+++ b/labs/04_entrada_boton/05_interrupcion_exti/README.md
@@ -80,7 +80,8 @@ Este mecanismo permite que el programa "salte automáticamente" a ejecutar una f
 ### Temporizador TIM2
 
 * Se configura para generar una interrupción cada 1 ms.
-* Se ajustan `prescaler` y `period` usando `rcc_ahb_frequency`.
+* Se ajustan `prescaler` y `period` a partir de la frecuencia real del
+  temporizador, calculada con `rcc_apb1_frequency`.
 * En su ISR, esperamos a que la lectura de la entrada sea estable durante 20 ms.
 
 ---

--- a/labs/04_entrada_boton/05_interrupcion_exti/main.c
+++ b/labs/04_entrada_boton/05_interrupcion_exti/main.c
@@ -9,7 +9,11 @@
 #define UMBRAL_ESTABILIDAD     20        // 20 lecturas estables → se requieren 20 ms de estabilidad
 #define TIMER_PRESCALER        7200      // 72 MHz / 7200 = 10 kHz
 #define TIMER_FREQ_HZ          1000      // 10 kHz / 10 = 1 kHz (1 ms entre interrupciones)
-#define TIMER_PERIOD           (rcc_ahb_frequency / TIMER_PRESCALER / TIMER_FREQ_HZ)
+// TIMER_CLOCK_HZ calcula la frecuencia real que alimenta a TIM2. Si el bus
+// APB1 tiene prescaler diferente de 1, la señal al timer se duplica.
+#define TIMER_CLOCK_HZ         ((rcc_apb1_frequency == rcc_ahb_frequency) ? \
+                                rcc_apb1_frequency : rcc_apb1_frequency * 2)
+#define TIMER_PERIOD           (TIMER_CLOCK_HZ / TIMER_PRESCALER / TIMER_FREQ_HZ)
 
 // === Variables globales (compartidas entre main e ISRs) ===
 volatile int contador_estabilidad   = 0;


### PR DESCRIPTION
## Summary
- compute TIM2 clock using APB1 frequency
- document new formula in antirrebote examples

## Testing
- `make` *(fails: arm-none-eabi-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f41916a84832393e04f28ce4bf7b9