### PR TITLE
Add Unity tests with hardware stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ output/
 *.swp
 .DS_Store
 Thumbs.db
+tests/test_runner

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	$(MAKE) -C tests run

--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ Para flashear con OpenOCD:
 make flash
 ```
 
+## 🧪 Tests
+
+Se provee un entorno de pruebas basado en [Unity](https://www.throwtheswitch.org/unity) para
+ejecutar el código en el host, con implementaciones ficticias de las funciones de `libopencm3` y FreeRTOS.
+Para compilar y correr todos los tests simplemente ejecutá:
+
+```bash
+make test
+```
+
+Esto compila los test dentro de `tests/` y corre el binario resultante.
+
 ---
 
 ## 🧠 Detalles técnicos importantes

--- a/freertos-labs/01_blink_task/main.c
+++ b/freertos-labs/01_blink_task/main.c
@@ -15,6 +15,7 @@ void led_task(void *args) {
     }
 }
 
+#ifndef UNIT_TEST
 int main(void) {
     rcc_clock_setup_pll(&rcc_hse_configs[RCC_CLOCK_HSE8_72MHZ]);    
 
@@ -29,4 +30,5 @@ int main(void) {
     gpio_clear(GPIOC, GPIO13);  // LED ON
     while (1);  // Esperá congelado
 }
+#endif // UNIT_TEST
 

--- a/freertos-labs/02_uart_echo_queue/main.c
+++ b/freertos-labs/02_uart_echo_queue/main.c
@@ -90,6 +90,7 @@ static void gpio_setup(void) {
     
 }
 
+#ifndef UNIT_TEST
 int main(void) {
     rcc_clock_setup_pll(&rcc_hse_configs[RCC_CLOCK_HSE8_72MHZ]);
 
@@ -106,3 +107,4 @@ int main(void) {
 
     while (1); // no debería llegar nunca
 }
+#endif // UNIT_TEST

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,17 @@
+CC=gcc
+CFLAGS=-I../tests/stubs -I../tests/unity -DUNIT_TEST -std=c99
+
+SRCS=$(wildcard test_*.c)
+OBJS=$(SRCS:.c=.o) stubs/freertos_stubs.o stubs/libopencm3_stubs.o unity/unity.o
+
+all: $(OBJS)
+	$(CC) $(CFLAGS) -o test_runner $(OBJS)
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJS) test_runner
+
+run: all
+	./test_runner

--- a/tests/stubs/FreeRTOS.h
+++ b/tests/stubs/FreeRTOS.h
@@ -1,0 +1,29 @@
+#ifndef FREERTOS_STUB_H
+#define FREERTOS_STUB_H
+#include <stdint.h>
+#include <setjmp.h>
+
+typedef void* QueueHandle_t;
+typedef int32_t BaseType_t;
+typedef uint32_t UBaseType_t;
+typedef uint32_t TickType_t;
+
+#define pdPASS 1
+#define pdFALSE 0
+#define pdMS_TO_TICKS(x) (x)
+#define portMAX_DELAY 0xffffffff
+
+extern jmp_buf test_jmp_buf;
+extern int jump_after_delay;
+extern int jump_after_receive;
+
+QueueHandle_t xQueueCreate(UBaseType_t length, UBaseType_t item_size);
+BaseType_t xQueueReceive(QueueHandle_t q, void *item, TickType_t timeout);
+BaseType_t xQueueSendFromISR(QueueHandle_t q, const void *item, BaseType_t *hpw);
+BaseType_t xTaskCreate(void (*task)(void*), const char *name, uint16_t stack,
+                       void *params, UBaseType_t prio, void *handle);
+void vTaskDelay(TickType_t ticks);
+void vTaskStartScheduler(void);
+void portYIELD_FROM_ISR(BaseType_t x);
+
+#endif // FREERTOS_STUB_H

--- a/tests/stubs/freertos.h
+++ b/tests/stubs/freertos.h
@@ -1,0 +1,29 @@
+#ifndef FREERTOS_STUB_H
+#define FREERTOS_STUB_H
+#include <stdint.h>
+#include <setjmp.h>
+
+typedef void* QueueHandle_t;
+typedef int32_t BaseType_t;
+typedef uint32_t UBaseType_t;
+typedef uint32_t TickType_t;
+
+#define pdPASS 1
+#define pdFALSE 0
+#define pdMS_TO_TICKS(x) (x)
+#define portMAX_DELAY 0xffffffff
+
+extern jmp_buf test_jmp_buf;
+extern int jump_after_delay;
+extern int jump_after_receive;
+
+QueueHandle_t xQueueCreate(UBaseType_t length, UBaseType_t item_size);
+BaseType_t xQueueReceive(QueueHandle_t q, void *item, TickType_t timeout);
+BaseType_t xQueueSendFromISR(QueueHandle_t q, const void *item, BaseType_t *hpw);
+BaseType_t xTaskCreate(void (*task)(void*), const char *name, uint16_t stack,
+                       void *params, UBaseType_t prio, void *handle);
+void vTaskDelay(TickType_t ticks);
+void vTaskStartScheduler(void);
+void portYIELD_FROM_ISR(BaseType_t x);
+
+#endif // FREERTOS_STUB_H

--- a/tests/stubs/freertos_stubs.c
+++ b/tests/stubs/freertos_stubs.c
@@ -1,0 +1,67 @@
+#include "freertos.h"
+#include <stdlib.h>
+#include <string.h>
+
+jmp_buf test_jmp_buf;
+int jump_after_delay = 0;
+int jump_after_receive = 0;
+
+typedef struct {
+    char *buffer;
+    UBaseType_t size;
+    UBaseType_t head;
+    UBaseType_t tail;
+    UBaseType_t count;
+} StubQueue;
+
+QueueHandle_t xQueueCreate(UBaseType_t length, UBaseType_t item_size) {
+    (void)item_size;
+    StubQueue *q = calloc(1, sizeof(StubQueue));
+    q->buffer = calloc(length, sizeof(char));
+    q->size = length;
+    return (QueueHandle_t)q;
+}
+
+BaseType_t xQueueReceive(QueueHandle_t handle, void *item, TickType_t timeout) {
+    (void)timeout;
+    StubQueue *q = (StubQueue*)handle;
+    if (q->count == 0) {
+        if (jump_after_receive > 0) {
+            jump_after_receive--;
+            if (jump_after_receive == 0) longjmp(test_jmp_buf, 1);
+        }
+        return pdFALSE;
+    }
+    *((char*)item) = q->buffer[q->tail];
+    q->tail = (q->tail + 1) % q->size;
+    q->count--;
+    if (jump_after_receive > 0) {
+        jump_after_receive--;
+        if (jump_after_receive == 0) longjmp(test_jmp_buf, 1);
+    }
+    return pdPASS;
+}
+
+BaseType_t xQueueSendFromISR(QueueHandle_t handle, const void *item, BaseType_t *hpw) {
+    (void)hpw;
+    StubQueue *q = (StubQueue*)handle;
+    if (q->count >= q->size) return !pdPASS;
+    q->buffer[q->head] = *(const char*)item;
+    q->head = (q->head + 1) % q->size;
+    q->count++;
+    return pdPASS;
+}
+
+BaseType_t xTaskCreate(void (*task)(void*), const char *name, uint16_t stack,
+                       void *params, UBaseType_t prio, void *handle) {
+    (void)task; (void)name; (void)stack; (void)params; (void)prio; (void)handle;
+    return pdPASS;
+}
+
+void vTaskDelay(TickType_t ticks) {
+    (void)ticks;
+    if (jump_after_delay) { jump_after_delay = 0; longjmp(test_jmp_buf, 1); }
+}
+
+void vTaskStartScheduler(void) {}
+void portYIELD_FROM_ISR(BaseType_t x) { (void)x; }

--- a/tests/stubs/libopencm3.h
+++ b/tests/stubs/libopencm3.h
@@ -1,0 +1,61 @@
+#ifndef LIBOPENCM3_STUB_H
+#define LIBOPENCM3_STUB_H
+#include <stdint.h>
+
+#define GPIOC 0
+#define GPIOA 1
+#define GPIO9 9
+#define GPIO10 10
+#define GPIO13 13
+#define GPIO_MODE_OUTPUT_2_MHZ 0
+#define GPIO_MODE_OUTPUT_50_MHZ 0
+#define GPIO_MODE_INPUT 0
+#define GPIO_CNF_OUTPUT_PUSHPULL 0
+#define GPIO_CNF_OUTPUT_ALTFN_PUSHPULL 0
+#define GPIO_CNF_INPUT_PULL_UPDOWN 0
+
+#define RCC_GPIOC 0
+#define RCC_GPIOA 0
+#define RCC_USART1 0
+
+#define USART1 0
+#define USART_STOPBITS_1 0
+#define USART_MODE_TX_RX 0
+#define USART_PARITY_NONE 0
+#define USART_FLOWCONTROL_NONE 0
+
+#define NVIC_USART1_IRQ 0
+#define USART_SR_RXNE 0
+
+struct rcc_clock_scale { int dummy; };
+extern const struct rcc_clock_scale rcc_hse_configs[];
+#define RCC_CLOCK_HSE8_72MHZ 0
+
+void rcc_clock_setup_pll(const struct rcc_clock_scale *);
+void rcc_periph_clock_enable(uint32_t periph);
+
+void gpio_set_mode(uint32_t port, uint8_t mode, uint8_t cnf, uint16_t pin);
+void gpio_toggle(uint32_t port, uint16_t pin);
+void gpio_set(uint32_t port, uint16_t pin);
+void gpio_clear(uint32_t port, uint16_t pin);
+
+void usart_set_baudrate(uint32_t usart, uint32_t baud);
+void usart_set_databits(uint32_t usart, uint32_t bits);
+void usart_set_stopbits(uint32_t usart, uint32_t stopbits);
+void usart_set_mode(uint32_t usart, uint32_t mode);
+void usart_set_parity(uint32_t usart, uint32_t parity);
+void usart_set_flow_control(uint32_t usart, uint32_t flow);
+void usart_enable(uint32_t usart);
+void usart_enable_rx_interrupt(uint32_t usart);
+int usart_get_flag(uint32_t usart, uint32_t flag);
+char usart_recv(uint32_t usart);
+void usart_send_blocking(uint32_t usart, char data);
+
+void nvic_set_priority(uint8_t irq, uint8_t prio);
+void nvic_enable_irq(uint8_t irq);
+
+extern int gpio_toggle_count;
+extern char usart_send_buffer[256];
+extern int usart_send_count;
+
+#endif // LIBOPENCM3_STUB_H

--- a/tests/stubs/libopencm3/cm3/nvic.h
+++ b/tests/stubs/libopencm3/cm3/nvic.h
@@ -1,0 +1,1 @@
+#include "../../libopencm3.h"

--- a/tests/stubs/libopencm3/stm32/gpio.h
+++ b/tests/stubs/libopencm3/stm32/gpio.h
@@ -1,0 +1,1 @@
+#include "../../libopencm3.h"

--- a/tests/stubs/libopencm3/stm32/rcc.h
+++ b/tests/stubs/libopencm3/stm32/rcc.h
@@ -1,0 +1,1 @@
+#include "../../libopencm3.h"

--- a/tests/stubs/libopencm3/stm32/usart.h
+++ b/tests/stubs/libopencm3/stm32/usart.h
@@ -1,0 +1,1 @@
+#include "../../libopencm3.h"

--- a/tests/stubs/libopencm3_stubs.c
+++ b/tests/stubs/libopencm3_stubs.c
@@ -1,0 +1,42 @@
+#include "libopencm3.h"
+#include "freertos.h"
+#include <stdio.h>
+
+const struct rcc_clock_scale rcc_hse_configs[] = { {0} };
+
+int gpio_toggle_count = 0;
+char usart_send_buffer[256];
+int usart_send_count = 0;
+
+void rcc_clock_setup_pll(const struct rcc_clock_scale *cfg) { (void)cfg; }
+void rcc_periph_clock_enable(uint32_t periph) { (void)periph; }
+
+void gpio_set_mode(uint32_t port, uint8_t mode, uint8_t cnf, uint16_t pin) {
+    (void)port; (void)mode; (void)cnf; (void)pin;
+}
+
+void gpio_toggle(uint32_t port, uint16_t pin) {
+    (void)port; (void)pin;
+    gpio_toggle_count++;
+}
+
+void gpio_set(uint32_t port, uint16_t pin) { (void)port; (void)pin; }
+void gpio_clear(uint32_t port, uint16_t pin) { (void)port; (void)pin; }
+
+void usart_set_baudrate(uint32_t usart, uint32_t baud) { (void)usart; (void)baud; }
+void usart_set_databits(uint32_t usart, uint32_t bits) { (void)usart; (void)bits; }
+void usart_set_stopbits(uint32_t usart, uint32_t stopbits) { (void)usart; (void)stopbits; }
+void usart_set_mode(uint32_t usart, uint32_t mode) { (void)usart; (void)mode; }
+void usart_set_parity(uint32_t usart, uint32_t parity) { (void)usart; (void)parity; }
+void usart_set_flow_control(uint32_t usart, uint32_t flow) { (void)usart; (void)flow; }
+void usart_enable(uint32_t usart) { (void)usart; }
+void usart_enable_rx_interrupt(uint32_t usart) { (void)usart; }
+int usart_get_flag(uint32_t usart, uint32_t flag) { (void)usart; (void)flag; return 0; }
+char usart_recv(uint32_t usart) { (void)usart; return 0; }
+void usart_send_blocking(uint32_t usart, char data) {
+    (void)usart;
+    usart_send_buffer[usart_send_count++] = data;
+}
+
+void nvic_set_priority(uint8_t irq, uint8_t prio) { (void)irq; (void)prio; }
+void nvic_enable_irq(uint8_t irq) { (void)irq; }

--- a/tests/stubs/queue.h
+++ b/tests/stubs/queue.h
@@ -1,0 +1,1 @@
+#include "freertos.h"

--- a/tests/stubs/stubs.h
+++ b/tests/stubs/stubs.h
@@ -1,0 +1,2 @@
+#include "freertos.h"
+#include "libopencm3.h"

--- a/tests/stubs/task.h
+++ b/tests/stubs/task.h
@@ -1,0 +1,1 @@
+#include "freertos.h"

--- a/tests/test_echo_task.c
+++ b/tests/test_echo_task.c
@@ -1,0 +1,33 @@
+#include "unity/unity.h"
+#include "stubs/stubs.h"
+
+#include "../freertos-labs/02_uart_echo_queue/main.c"
+
+
+void test_echo_cr_lf(void) {
+    rx_queue = xQueueCreate(4, sizeof(char));
+    char ch = '\r';
+    xQueueSendFromISR(rx_queue, &ch, NULL);
+    jump_after_receive = 2;
+    usart_send_count = 0;
+    if (setjmp(test_jmp_buf) == 0) {
+        echo_task(NULL);
+    }
+    TEST_ASSERT_EQUAL_INT(2, usart_send_count);
+    TEST_ASSERT_EQUAL_CHAR('\r', usart_send_buffer[0]);
+    TEST_ASSERT_EQUAL_CHAR('\n', usart_send_buffer[1]);
+}
+
+void test_echo_regular_char(void) {
+    rx_queue = xQueueCreate(4, sizeof(char));
+    char ch = 'A';
+    xQueueSendFromISR(rx_queue, &ch, NULL);
+    jump_after_receive = 2;
+    usart_send_count = 0;
+    if (setjmp(test_jmp_buf) == 0) {
+        echo_task(NULL);
+    }
+    TEST_ASSERT_EQUAL_INT(1, usart_send_count);
+    TEST_ASSERT_EQUAL_CHAR('A', usart_send_buffer[0]);
+}
+

--- a/tests/test_led_task.c
+++ b/tests/test_led_task.c
@@ -1,0 +1,14 @@
+#include "unity/unity.h"
+#include "stubs/stubs.h"
+
+// Include the code under test
+#include "../freertos-labs/01_blink_task/main.c"
+
+void test_led_task_toggles_once(void) {
+    gpio_toggle_count = 0;
+    jump_after_delay = 1;
+    if (setjmp(test_jmp_buf) == 0) {
+        led_task(NULL);
+    }
+    TEST_ASSERT_EQUAL_INT(1, gpio_toggle_count);
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1,0 +1,16 @@
+#include "unity/unity.h"
+
+void test_led_task_toggles_once(void);
+void test_echo_cr_lf(void);
+void test_echo_regular_char(void);
+
+void setUp(void) {}
+void tearDown(void) {}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_led_task_toggles_once);
+    RUN_TEST(test_echo_cr_lf);
+    RUN_TEST(test_echo_regular_char);
+    return UNITY_END();
+}

--- a/tests/unity/unity.c
+++ b/tests/unity/unity.c
@@ -1,0 +1,32 @@
+#include "unity.h"
+static int tests_run;
+static int tests_failed;
+
+void UnityBegin(void) {
+    tests_run = 0;
+    tests_failed = 0;
+}
+
+void UnityAssertEqualNumber(int expected, int actual, const char* msg, int line) {
+    tests_run++;
+    if (expected != actual) {
+        tests_failed++;
+        printf("%s:%d: %s Expected %d Was %d\n", __FILE__, line, msg, expected, actual);
+    }
+}
+
+void UnityFail(int line, const char* msg) {
+    tests_run++;
+    tests_failed++;
+    printf("%s:%d: %s\n", __FILE__, line, msg);
+}
+
+void UnityDefaultTestRun(void (*func)(void), const char* name, int line) {
+    (void)name; (void)line;
+    func();
+}
+
+int UnityEnd(void) {
+    printf("Ran %d tests: %d failures\n", tests_run, tests_failed);
+    return tests_failed;
+}

--- a/tests/unity/unity.h
+++ b/tests/unity/unity.h
@@ -1,0 +1,18 @@
+#ifndef UNITY_H
+#define UNITY_H
+#include <stdio.h>
+
+void UnityBegin(void);
+int UnityEnd(void);
+void UnityAssertEqualNumber(int expected, int actual, const char* msg, int line);
+void UnityFail(int line, const char* msg);
+void UnityDefaultTestRun(void (*func)(void), const char* name, int line);
+
+#define UNITY_BEGIN() UnityBegin()
+#define UNITY_END() UnityEnd()
+#define RUN_TEST(func) UnityDefaultTestRun(func, #func, __LINE__)
+#define TEST_ASSERT_EQUAL_INT(expected, actual) UnityAssertEqualNumber((expected), (actual), "TEST_ASSERT_EQUAL_INT", __LINE__)
+#define TEST_ASSERT_EQUAL_CHAR(expected, actual) UnityAssertEqualNumber((expected), (actual), "TEST_ASSERT_EQUAL_CHAR", __LINE__)
+#define TEST_FAIL_MESSAGE(msg) UnityFail(__LINE__, msg)
+
+#endif


### PR DESCRIPTION
## Summary
- add Makefile with `test` target
- create Unity-based `tests/` harness
- stub libopencm3 and FreeRTOS functions so tasks run on host
- wrap main functions in labs with `UNIT_TEST` guard
- document running tests in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6841aacfeed08323baa6445759beb7fe