### PR TITLE
Add FSM variants lab with tests

### DIFF
--- a/freertos-labs/06_fsm_variants/README.md
+++ b/freertos-labs/06_fsm_variants/README.md
@@ -1,0 +1,62 @@
+# Laboratorio 06 - Variantes de FSM en C
+
+Este ejemplo muestra cuatro maneras distintas de implementar una misma máquina de estados finita (FSM) en C puro. Cada variante vive en su propia carpeta y expone la misma función pública `fsm_handle_event()` para procesar un evento.
+
+## Descripción de la FSM
+
+La máquina de estados controla un LED imaginario y responde a comandos simulados por UART:
+
+* Estados:
+  * `OFF`
+  * `BLINK_SLOW` (1 Hz)
+  * `BLINK_FAST` (5 Hz)
+  * `ERROR`
+* Eventos de entrada:
+  * `'0'` → pasar a `OFF`
+  * `'1'` → pasar a `BLINK_SLOW`
+  * `'2'` → pasar a `BLINK_FAST`
+  * otro caracter → `ERROR`
+
+La transición se produce al invocar `fsm_handle_event()` con un `fsm_event_t`.
+
+## Implementaciones
+
+| Carpeta            | Descripción breve                               |
+|--------------------|-------------------------------------------------|
+| `switch_case/`     | Estructura clásica con `switch` anidados por estado y evento. |
+| `func_pointer/`    | Usa un arreglo de punteros a función para cada estado. |
+| `transition_table/`| Implementa una tabla de transición `estado × evento`.| 
+| `state_pattern/`   | Aplica el *State Pattern* con funciones asociadas a cada estado.| 
+
+### Ventajas y desventajas
+
+* **Switch/Case**: simple y directo, pero puede crecer rápidamente en tamaño.
+* **Punteros a función**: separa el código por estado y facilita extender nuevas acciones.
+* **Tabla de transición**: compacta y fácil de visualizar, ideal para FSM simples.
+* **State Pattern**: más flexible y escalable, aunque algo verboso para casos pequeños.
+
+### ¿Cuándo usar cada una?
+
+* `switch_case/`: para FSM pequeñas o prototipos rápidos.
+* `func_pointer/`: cuando cada estado tiene comportamientos bien diferenciados.
+* `transition_table/`: si la FSM es muy regular y las acciones son breves.
+* `state_pattern/`: en proyectos grandes donde se requiera extensibilidad.
+
+## Compilación y ejecución
+
+Cada variante cuenta con su propio `Makefile`. Por ejemplo:
+
+```bash
+make -C switch_case run
+```
+
+Los tests unitarios se encuentran en `tests/` y se ejecutan con:
+
+```bash
+make -C tests run
+```
+
+## ¿Qué es una FSM?
+
+Una *máquina de estados finita* describe el comportamiento de un sistema que puede estar en un conjunto limitado de estados y cambiar entre ellos según eventos externos. En sistemas embebidos se utiliza para modelar protocolos, manejos de periféricos y secuencias de control de manera clara y mantenible.
+

--- a/freertos-labs/06_fsm_variants/func_pointer/Makefile
+++ b/freertos-labs/06_fsm_variants/func_pointer/Makefile
@@ -1,0 +1,13 @@
+CC=gcc
+CFLAGS=-I../include -std=c99 -Wall -Wextra
+
+all: main
+
+main: main.c fsm_func_pointer.c
+$(CC) $(CFLAGS) $^ -o main
+
+clean:
+rm -f main
+
+run: main
+./main

--- a/freertos-labs/06_fsm_variants/func_pointer/fsm_func_pointer.c
+++ b/freertos-labs/06_fsm_variants/func_pointer/fsm_func_pointer.c
@@ -1,0 +1,112 @@
+#include "../include/fsm.h"
+
+static fsm_state_t current_state = STATE_OFF;
+
+static void enter_state(fsm_state_t state) {
+    switch (state) {
+    case STATE_OFF: printf("LED OFF\n"); break;
+    case STATE_BLINK_SLOW: printf("Blinking SLOW\n"); break;
+    case STATE_BLINK_FAST: printf("Blinking FAST\n"); break;
+    case STATE_ERROR: printf("ERROR state\n"); break;
+    }
+}
+
+static void handle_off(fsm_event_t e);
+static void handle_blink_slow(fsm_event_t e);
+static void handle_blink_fast(fsm_event_t e);
+static void handle_error(fsm_event_t e);
+
+static void (*handlers[])(fsm_event_t) = {
+    handle_off,
+    handle_blink_slow,
+    handle_blink_fast,
+    handle_error
+};
+
+void fsm_reset(void) { current_state = STATE_OFF; }
+
+fsm_state_t fsm_get_state(void) { return current_state; }
+
+static void handle_off(fsm_event_t e) {
+    switch (e.type) {
+    case EVENT_CMD_0:
+        enter_state(STATE_OFF);
+        break;
+    case EVENT_CMD_1:
+        current_state = STATE_BLINK_SLOW;
+        enter_state(current_state);
+        break;
+    case EVENT_CMD_2:
+        current_state = STATE_BLINK_FAST;
+        enter_state(current_state);
+        break;
+    default:
+        current_state = STATE_ERROR;
+        enter_state(current_state);
+        break;
+    }
+}
+
+static void handle_blink_slow(fsm_event_t e) {
+    switch (e.type) {
+    case EVENT_CMD_0:
+        current_state = STATE_OFF;
+        enter_state(current_state);
+        break;
+    case EVENT_CMD_1:
+        enter_state(STATE_BLINK_SLOW);
+        break;
+    case EVENT_CMD_2:
+        current_state = STATE_BLINK_FAST;
+        enter_state(current_state);
+        break;
+    default:
+        current_state = STATE_ERROR;
+        enter_state(current_state);
+        break;
+    }
+}
+
+static void handle_blink_fast(fsm_event_t e) {
+    switch (e.type) {
+    case EVENT_CMD_0:
+        current_state = STATE_OFF;
+        enter_state(current_state);
+        break;
+    case EVENT_CMD_1:
+        current_state = STATE_BLINK_SLOW;
+        enter_state(current_state);
+        break;
+    case EVENT_CMD_2:
+        enter_state(STATE_BLINK_FAST);
+        break;
+    default:
+        current_state = STATE_ERROR;
+        enter_state(current_state);
+        break;
+    }
+}
+
+static void handle_error(fsm_event_t e) {
+    switch (e.type) {
+    case EVENT_CMD_0:
+        current_state = STATE_OFF;
+        enter_state(current_state);
+        break;
+    case EVENT_CMD_1:
+        current_state = STATE_BLINK_SLOW;
+        enter_state(current_state);
+        break;
+    case EVENT_CMD_2:
+        current_state = STATE_BLINK_FAST;
+        enter_state(current_state);
+        break;
+    default:
+        enter_state(STATE_ERROR);
+        break;
+    }
+}
+
+void fsm_handle_event(fsm_event_t event) {
+    handlers[current_state](event);
+}

--- a/freertos-labs/06_fsm_variants/func_pointer/main.c
+++ b/freertos-labs/06_fsm_variants/func_pointer/main.c
@@ -1,0 +1,21 @@
+#include "../include/fsm.h"
+#include <stdio.h>
+
+static fsm_event_t event_from_char(char c) {
+    switch (c) {
+    case '0': return (fsm_event_t){EVENT_CMD_0};
+    case '1': return (fsm_event_t){EVENT_CMD_1};
+    case '2': return (fsm_event_t){EVENT_CMD_2};
+    default:  return (fsm_event_t){EVENT_INVALID};
+    }
+}
+
+int main(void) {
+    const char seq[] = {'1','2','0','x','\0'};
+    fsm_reset();
+    for (int i=0; seq[i] != '\0'; ++i) {
+        printf("Input: %c\n", seq[i]);
+        fsm_handle_event(event_from_char(seq[i]));
+    }
+    return 0;
+}

--- a/freertos-labs/06_fsm_variants/include/fsm.h
+++ b/freertos-labs/06_fsm_variants/include/fsm.h
@@ -1,0 +1,28 @@
+#ifndef FSM_H
+#define FSM_H
+
+#include <stdio.h>
+
+typedef enum {
+    STATE_OFF,
+    STATE_BLINK_SLOW,
+    STATE_BLINK_FAST,
+    STATE_ERROR
+} fsm_state_t;
+
+typedef enum {
+    EVENT_CMD_0,
+    EVENT_CMD_1,
+    EVENT_CMD_2,
+    EVENT_INVALID
+} fsm_event_type_t;
+
+typedef struct {
+    fsm_event_type_t type;
+} fsm_event_t;
+
+void fsm_handle_event(fsm_event_t event);
+fsm_state_t fsm_get_state(void);
+void fsm_reset(void);
+
+#endif // FSM_H

--- a/freertos-labs/06_fsm_variants/state_pattern/Makefile
+++ b/freertos-labs/06_fsm_variants/state_pattern/Makefile
@@ -1,0 +1,13 @@
+CC=gcc
+CFLAGS=-I../include -std=c99 -Wall -Wextra
+
+all: main
+
+main: main.c fsm_state_pattern.c
+$(CC) $(CFLAGS) $^ -o main
+
+clean:
+rm -f main
+
+run: main
+./main

--- a/freertos-labs/06_fsm_variants/state_pattern/fsm_state_pattern.c
+++ b/freertos-labs/06_fsm_variants/state_pattern/fsm_state_pattern.c
@@ -1,0 +1,114 @@
+#include "../include/fsm.h"
+
+typedef void (*state_func_t)(fsm_event_t);
+
+static fsm_state_t current_state = STATE_OFF;
+
+static void enter_state(fsm_state_t s) {
+    switch (s) {
+    case STATE_OFF: printf("LED OFF\n"); break;
+    case STATE_BLINK_SLOW: printf("Blinking SLOW\n"); break;
+    case STATE_BLINK_FAST: printf("Blinking FAST\n"); break;
+    case STATE_ERROR: printf("ERROR state\n"); break;
+    }
+}
+
+static void state_off(fsm_event_t e);
+static void state_blink_slow(fsm_event_t e);
+static void state_blink_fast(fsm_event_t e);
+static void state_error(fsm_event_t e);
+
+static state_func_t state_handlers[] = {
+    state_off,
+    state_blink_slow,
+    state_blink_fast,
+    state_error
+};
+
+void fsm_reset(void) { current_state = STATE_OFF; }
+
+fsm_state_t fsm_get_state(void) { return current_state; }
+
+static void state_off(fsm_event_t e) {
+    switch (e.type) {
+    case EVENT_CMD_0:
+        enter_state(STATE_OFF);
+        break;
+    case EVENT_CMD_1:
+        current_state = STATE_BLINK_SLOW;
+        enter_state(current_state);
+        break;
+    case EVENT_CMD_2:
+        current_state = STATE_BLINK_FAST;
+        enter_state(current_state);
+        break;
+    default:
+        current_state = STATE_ERROR;
+        enter_state(current_state);
+        break;
+    }
+}
+
+static void state_blink_slow(fsm_event_t e) {
+    switch (e.type) {
+    case EVENT_CMD_0:
+        current_state = STATE_OFF;
+        enter_state(current_state);
+        break;
+    case EVENT_CMD_1:
+        enter_state(STATE_BLINK_SLOW);
+        break;
+    case EVENT_CMD_2:
+        current_state = STATE_BLINK_FAST;
+        enter_state(current_state);
+        break;
+    default:
+        current_state = STATE_ERROR;
+        enter_state(current_state);
+        break;
+    }
+}
+
+static void state_blink_fast(fsm_event_t e) {
+    switch (e.type) {
+    case EVENT_CMD_0:
+        current_state = STATE_OFF;
+        enter_state(current_state);
+        break;
+    case EVENT_CMD_1:
+        current_state = STATE_BLINK_SLOW;
+        enter_state(current_state);
+        break;
+    case EVENT_CMD_2:
+        enter_state(STATE_BLINK_FAST);
+        break;
+    default:
+        current_state = STATE_ERROR;
+        enter_state(current_state);
+        break;
+    }
+}
+
+static void state_error(fsm_event_t e) {
+    switch (e.type) {
+    case EVENT_CMD_0:
+        current_state = STATE_OFF;
+        enter_state(current_state);
+        break;
+    case EVENT_CMD_1:
+        current_state = STATE_BLINK_SLOW;
+        enter_state(current_state);
+        break;
+    case EVENT_CMD_2:
+        current_state = STATE_BLINK_FAST;
+        enter_state(current_state);
+        break;
+    default:
+        enter_state(STATE_ERROR);
+        break;
+    }
+}
+
+void fsm_handle_event(fsm_event_t event) {
+    state_handlers[current_state](event);
+}

--- a/freertos-labs/06_fsm_variants/state_pattern/main.c
+++ b/freertos-labs/06_fsm_variants/state_pattern/main.c
@@ -1,0 +1,21 @@
+#include "../include/fsm.h"
+#include <stdio.h>
+
+static fsm_event_t event_from_char(char c) {
+    switch (c) {
+    case '0': return (fsm_event_t){EVENT_CMD_0};
+    case '1': return (fsm_event_t){EVENT_CMD_1};
+    case '2': return (fsm_event_t){EVENT_CMD_2};
+    default:  return (fsm_event_t){EVENT_INVALID};
+    }
+}
+
+int main(void) {
+    const char seq[] = {'1','2','0','x','\0'};
+    fsm_reset();
+    for (int i=0; seq[i] != '\0'; ++i) {
+        printf("Input: %c\n", seq[i]);
+        fsm_handle_event(event_from_char(seq[i]));
+    }
+    return 0;
+}

--- a/freertos-labs/06_fsm_variants/switch_case/Makefile
+++ b/freertos-labs/06_fsm_variants/switch_case/Makefile
@@ -1,0 +1,13 @@
+CC=gcc
+CFLAGS=-I../include -std=c99 -Wall -Wextra
+
+all: main
+
+main: main.c fsm_switch_case.c
+$(CC) $(CFLAGS) $^ -o main
+
+clean:
+rm -f main
+
+run: main
+./main

--- a/freertos-labs/06_fsm_variants/switch_case/fsm_switch_case.c
+++ b/freertos-labs/06_fsm_variants/switch_case/fsm_switch_case.c
@@ -1,0 +1,109 @@
+#include "../include/fsm.h"
+
+static fsm_state_t current_state = STATE_OFF;
+
+static void enter_state(fsm_state_t state) {
+    switch (state) {
+    case STATE_OFF:
+        printf("LED OFF\n");
+        break;
+    case STATE_BLINK_SLOW:
+        printf("Blinking SLOW\n");
+        break;
+    case STATE_BLINK_FAST:
+        printf("Blinking FAST\n");
+        break;
+    case STATE_ERROR:
+        printf("ERROR state\n");
+        break;
+    }
+}
+
+void fsm_reset(void) {
+    current_state = STATE_OFF;
+}
+
+fsm_state_t fsm_get_state(void) {
+    return current_state;
+}
+
+void fsm_handle_event(fsm_event_t event) {
+    switch (current_state) {
+    case STATE_OFF:
+        switch (event.type) {
+        case EVENT_CMD_0:
+            enter_state(STATE_OFF);
+            break;
+        case EVENT_CMD_1:
+            current_state = STATE_BLINK_SLOW;
+            enter_state(current_state);
+            break;
+        case EVENT_CMD_2:
+            current_state = STATE_BLINK_FAST;
+            enter_state(current_state);
+            break;
+        default:
+            current_state = STATE_ERROR;
+            enter_state(current_state);
+            break;
+        }
+        break;
+    case STATE_BLINK_SLOW:
+        switch (event.type) {
+        case EVENT_CMD_0:
+            current_state = STATE_OFF;
+            enter_state(current_state);
+            break;
+        case EVENT_CMD_1:
+            enter_state(STATE_BLINK_SLOW);
+            break;
+        case EVENT_CMD_2:
+            current_state = STATE_BLINK_FAST;
+            enter_state(current_state);
+            break;
+        default:
+            current_state = STATE_ERROR;
+            enter_state(current_state);
+            break;
+        }
+        break;
+    case STATE_BLINK_FAST:
+        switch (event.type) {
+        case EVENT_CMD_0:
+            current_state = STATE_OFF;
+            enter_state(current_state);
+            break;
+        case EVENT_CMD_1:
+            current_state = STATE_BLINK_SLOW;
+            enter_state(current_state);
+            break;
+        case EVENT_CMD_2:
+            enter_state(STATE_BLINK_FAST);
+            break;
+        default:
+            current_state = STATE_ERROR;
+            enter_state(current_state);
+            break;
+        }
+        break;
+    case STATE_ERROR:
+        switch (event.type) {
+        case EVENT_CMD_0:
+            current_state = STATE_OFF;
+            enter_state(current_state);
+            break;
+        case EVENT_CMD_1:
+            current_state = STATE_BLINK_SLOW;
+            enter_state(current_state);
+            break;
+        case EVENT_CMD_2:
+            current_state = STATE_BLINK_FAST;
+            enter_state(current_state);
+            break;
+        default:
+            enter_state(STATE_ERROR);
+            break;
+        }
+        break;
+    }
+}

--- a/freertos-labs/06_fsm_variants/switch_case/main.c
+++ b/freertos-labs/06_fsm_variants/switch_case/main.c
@@ -1,0 +1,25 @@
+#include "../include/fsm.h"
+#include <stdio.h>
+
+static fsm_event_t event_from_char(char c) {
+    switch (c) {
+    case '0':
+        return (fsm_event_t){EVENT_CMD_0};
+    case '1':
+        return (fsm_event_t){EVENT_CMD_1};
+    case '2':
+        return (fsm_event_t){EVENT_CMD_2};
+    default:
+        return (fsm_event_t){EVENT_INVALID};
+    }
+}
+
+int main(void) {
+    const char seq[] = {'1','2','0','x','\0'};
+    fsm_reset();
+    for (int i = 0; seq[i] != '\0'; ++i) {
+        printf("Input: %c\n", seq[i]);
+        fsm_handle_event(event_from_char(seq[i]));
+    }
+    return 0;
+}

--- a/freertos-labs/06_fsm_variants/tests/Makefile
+++ b/freertos-labs/06_fsm_variants/tests/Makefile
@@ -1,0 +1,21 @@
+CC=gcc
+UNITY_DIR=../../../tests/unity
+CFLAGS=-I$(UNITY_DIR) -I../include -std=c99 -Wall -Wextra
+
+TESTS=test_switch_case test_func_pointer test_transition_table test_state_pattern
+OBJS=$(addsuffix .o,$(TESTS)) $(UNITY_DIR)/unity.o
+EXES=$(addsuffix _runner,$(TESTS))
+
+all: $(EXES)
+
+%_runner: %.o $(UNITY_DIR)/unity.o
+	$(CC) $(CFLAGS) -o $@ $^
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(EXES) $(OBJS)
+
+run: $(EXES)
+	@for t in $(EXES); do ./$$t; done

--- a/freertos-labs/06_fsm_variants/tests/test_func_pointer.c
+++ b/freertos-labs/06_fsm_variants/tests/test_func_pointer.c
@@ -1,0 +1,24 @@
+#include "../../tests/unity/unity.h"
+#include "../include/fsm.h"
+
+#include "../func_pointer/fsm_func_pointer.c"
+
+void setUp(void) { fsm_reset(); }
+void tearDown(void) {}
+
+void test_func_pointer(void) {
+    fsm_handle_event((fsm_event_t){EVENT_CMD_1});
+    TEST_ASSERT_EQUAL_INT(STATE_BLINK_SLOW, fsm_get_state());
+    fsm_handle_event((fsm_event_t){EVENT_CMD_2});
+    TEST_ASSERT_EQUAL_INT(STATE_BLINK_FAST, fsm_get_state());
+    fsm_handle_event((fsm_event_t){EVENT_CMD_0});
+    TEST_ASSERT_EQUAL_INT(STATE_OFF, fsm_get_state());
+    fsm_handle_event((fsm_event_t){EVENT_INVALID});
+    TEST_ASSERT_EQUAL_INT(STATE_ERROR, fsm_get_state());
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_func_pointer);
+    return UNITY_END();
+}

--- a/freertos-labs/06_fsm_variants/tests/test_state_pattern.c
+++ b/freertos-labs/06_fsm_variants/tests/test_state_pattern.c
@@ -1,0 +1,24 @@
+#include "../../tests/unity/unity.h"
+#include "../include/fsm.h"
+
+#include "../state_pattern/fsm_state_pattern.c"
+
+void setUp(void) { fsm_reset(); }
+void tearDown(void) {}
+
+void test_state_pattern(void) {
+    fsm_handle_event((fsm_event_t){EVENT_CMD_1});
+    TEST_ASSERT_EQUAL_INT(STATE_BLINK_SLOW, fsm_get_state());
+    fsm_handle_event((fsm_event_t){EVENT_CMD_2});
+    TEST_ASSERT_EQUAL_INT(STATE_BLINK_FAST, fsm_get_state());
+    fsm_handle_event((fsm_event_t){EVENT_CMD_0});
+    TEST_ASSERT_EQUAL_INT(STATE_OFF, fsm_get_state());
+    fsm_handle_event((fsm_event_t){EVENT_INVALID});
+    TEST_ASSERT_EQUAL_INT(STATE_ERROR, fsm_get_state());
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_state_pattern);
+    return UNITY_END();
+}

--- a/freertos-labs/06_fsm_variants/tests/test_switch_case.c
+++ b/freertos-labs/06_fsm_variants/tests/test_switch_case.c
@@ -1,0 +1,24 @@
+#include "../../tests/unity/unity.h"
+#include "../include/fsm.h"
+
+#include "../switch_case/fsm_switch_case.c"
+
+void setUp(void) { fsm_reset(); }
+void tearDown(void) {}
+
+void test_switch_case(void) {
+    fsm_handle_event((fsm_event_t){EVENT_CMD_1});
+    TEST_ASSERT_EQUAL_INT(STATE_BLINK_SLOW, fsm_get_state());
+    fsm_handle_event((fsm_event_t){EVENT_CMD_2});
+    TEST_ASSERT_EQUAL_INT(STATE_BLINK_FAST, fsm_get_state());
+    fsm_handle_event((fsm_event_t){EVENT_CMD_0});
+    TEST_ASSERT_EQUAL_INT(STATE_OFF, fsm_get_state());
+    fsm_handle_event((fsm_event_t){EVENT_INVALID});
+    TEST_ASSERT_EQUAL_INT(STATE_ERROR, fsm_get_state());
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_switch_case);
+    return UNITY_END();
+}

--- a/freertos-labs/06_fsm_variants/tests/test_transition_table.c
+++ b/freertos-labs/06_fsm_variants/tests/test_transition_table.c
@@ -1,0 +1,24 @@
+#include "../../tests/unity/unity.h"
+#include "../include/fsm.h"
+
+#include "../transition_table/fsm_transition_table.c"
+
+void setUp(void) { fsm_reset(); }
+void tearDown(void) {}
+
+void test_transition_table(void) {
+    fsm_handle_event((fsm_event_t){EVENT_CMD_1});
+    TEST_ASSERT_EQUAL_INT(STATE_BLINK_SLOW, fsm_get_state());
+    fsm_handle_event((fsm_event_t){EVENT_CMD_2});
+    TEST_ASSERT_EQUAL_INT(STATE_BLINK_FAST, fsm_get_state());
+    fsm_handle_event((fsm_event_t){EVENT_CMD_0});
+    TEST_ASSERT_EQUAL_INT(STATE_OFF, fsm_get_state());
+    fsm_handle_event((fsm_event_t){EVENT_INVALID});
+    TEST_ASSERT_EQUAL_INT(STATE_ERROR, fsm_get_state());
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_transition_table);
+    return UNITY_END();
+}

--- a/freertos-labs/06_fsm_variants/transition_table/Makefile
+++ b/freertos-labs/06_fsm_variants/transition_table/Makefile
@@ -1,0 +1,13 @@
+CC=gcc
+CFLAGS=-I../include -std=c99 -Wall -Wextra
+
+all: main
+
+main: main.c fsm_transition_table.c
+$(CC) $(CFLAGS) $^ -o main
+
+clean:
+rm -f main
+
+run: main
+./main

--- a/freertos-labs/06_fsm_variants/transition_table/fsm_transition_table.c
+++ b/freertos-labs/06_fsm_variants/transition_table/fsm_transition_table.c
@@ -1,0 +1,29 @@
+#include "../include/fsm.h"
+
+static fsm_state_t current_state = STATE_OFF;
+
+static void enter_state(fsm_state_t s) {
+    switch (s) {
+    case STATE_OFF: printf("LED OFF\n"); break;
+    case STATE_BLINK_SLOW: printf("Blinking SLOW\n"); break;
+    case STATE_BLINK_FAST: printf("Blinking FAST\n"); break;
+    case STATE_ERROR: printf("ERROR state\n"); break;
+    }
+}
+
+static const fsm_state_t transition[4][4] = {
+    /* from OFF */           {STATE_OFF, STATE_BLINK_SLOW, STATE_BLINK_FAST, STATE_ERROR},
+    /* from BLINK_SLOW */    {STATE_OFF, STATE_BLINK_SLOW, STATE_BLINK_FAST, STATE_ERROR},
+    /* from BLINK_FAST */    {STATE_OFF, STATE_BLINK_SLOW, STATE_BLINK_FAST, STATE_ERROR},
+    /* from ERROR */         {STATE_OFF, STATE_BLINK_SLOW, STATE_BLINK_FAST, STATE_ERROR}
+};
+
+void fsm_reset(void) { current_state = STATE_OFF; }
+
+fsm_state_t fsm_get_state(void) { return current_state; }
+
+void fsm_handle_event(fsm_event_t event) {
+    if (event.type > EVENT_INVALID) event.type = EVENT_INVALID;
+    current_state = transition[current_state][event.type];
+    enter_state(current_state);
+}

--- a/freertos-labs/06_fsm_variants/transition_table/main.c
+++ b/freertos-labs/06_fsm_variants/transition_table/main.c
@@ -1,0 +1,21 @@
+#include "../include/fsm.h"
+#include <stdio.h>
+
+static fsm_event_t event_from_char(char c) {
+    switch (c) {
+    case '0': return (fsm_event_t){EVENT_CMD_0};
+    case '1': return (fsm_event_t){EVENT_CMD_1};
+    case '2': return (fsm_event_t){EVENT_CMD_2};
+    default:  return (fsm_event_t){EVENT_INVALID};
+    }
+}
+
+int main(void) {
+    const char seq[] = {'1','2','0','x','\0'};
+    fsm_reset();
+    for (int i=0; seq[i] != '\0'; ++i) {
+        printf("Input: %c\n", seq[i]);
+        fsm_handle_event(event_from_char(seq[i]));
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add 06_fsm_variants lab showing four FSM implementations
- provide switch/case, function pointer, table and state pattern styles
- include shared header and individual Makefiles
- add unit tests for each implementation with Unity

## Testing
- `make -C freertos-labs/06_fsm_variants/tests run`

------
https://chatgpt.com/codex/tasks/task_e_684206f71e48832389c775bb45930cea