### PR TITLE
Fix state pattern example

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             // Ruta al archivo ELF generado por la compilación
             // Este archivo contiene código, símbolos, información de depuración, etc.
             //"executable": "./bin/blink_minimal.elf",
-            "executable": "${workspaceFolder}/freertos-labs/06_fsm_variants/func_pointer/bin/main.elf",
+            "executable": "${workspaceFolder}/freertos-labs/06_fsm_variants/function_pointer/bin/main.elf",
             
 
 

--- a/freertos-labs/06_fsm_variants/README.md
+++ b/freertos-labs/06_fsm_variants/README.md
@@ -25,7 +25,7 @@ Cada variante crea una tarea llamada `fsm_task` que espera caracteres recibidos 
 | Carpeta            | Descripción breve |
 |--------------------|-------------------|
 | `switch_case/`     | `switch` anidados por estado y evento. |
-| `func_pointer/`    | Array de punteros a función para cada estado. |
+| `function_pointer/`| Array de punteros a función para cada estado. |
 | `transition_table/`| Tabla de transición `estado × evento`. |
 | `state_pattern/`   | Implementación del *State Pattern*. |
 
@@ -39,7 +39,7 @@ Cada variante crea una tarea llamada `fsm_task` que espera caracteres recibidos 
 ### ¿Cuándo usar cada una?
 
 * `switch_case/`: FSM pequeñas o prototipos rápidos.
-* `func_pointer/`: cuando los estados tienen comportamientos bien diferenciados.
+* `function_pointer/`: cuando los estados tienen comportamientos bien diferenciados.
 * `transition_table/`: si la FSM es regular y las acciones son breves.
 * `state_pattern/`: proyectos grandes que requieran extensibilidad.
 

--- a/freertos-labs/06_fsm_variants/function_pointer/Makefile
+++ b/freertos-labs/06_fsm_variants/function_pointer/Makefile
@@ -39,7 +39,7 @@ FREERTOS_SRC = \
     $(FREERTOS_DIR)/heap_4.c \
     $(FREERTOS_DIR)/portable/GCC/ARM_CM3/port.c
 
-SRC = main.c fsm_func_pointer.c $(FREERTOS_SRC)
+SRC = main.c fsm_function_pointer.c $(FREERTOS_SRC)
 
 OBJ = $(patsubst %.c, $(BUILD_DIR)/%.o, $(notdir $(SRC)))
 

--- a/freertos-labs/06_fsm_variants/function_pointer/fsm_function_pointer.c
+++ b/freertos-labs/06_fsm_variants/function_pointer/fsm_function_pointer.c
@@ -9,10 +9,12 @@ static void send_line(const char *msg)
     usart_send_blocking(USART1, '\n');
 }
 
+typedef void (*state_func_t)(fsm_event_t);
+
 static fsm_state_t current_state = STATE_OFF;
 
-static void enter_state(fsm_state_t state) {
-    switch (state) {
+static void enter_state(fsm_state_t s) {
+    switch (s) {
     case STATE_OFF: send_line("LED OFF"); break;
     case STATE_BLINK_SLOW: send_line("Blinking SLOW"); break;
     case STATE_BLINK_FAST: send_line("Blinking FAST"); break;
@@ -20,23 +22,23 @@ static void enter_state(fsm_state_t state) {
     }
 }
 
-static void handle_off(fsm_event_t e);
-static void handle_blink_slow(fsm_event_t e);
-static void handle_blink_fast(fsm_event_t e);
-static void handle_error(fsm_event_t e);
+static void state_off(fsm_event_t e);
+static void state_blink_slow(fsm_event_t e);
+static void state_blink_fast(fsm_event_t e);
+static void state_error(fsm_event_t e);
 
-static void (*handlers[])(fsm_event_t) = {
-    handle_off,
-    handle_blink_slow,
-    handle_blink_fast,
-    handle_error
+static state_func_t state_handlers[] = {
+    state_off,
+    state_blink_slow,
+    state_blink_fast,
+    state_error
 };
 
 void fsm_reset(void) { current_state = STATE_OFF; }
 
 fsm_state_t fsm_get_state(void) { return current_state; }
 
-static void handle_off(fsm_event_t e) {
+static void state_off(fsm_event_t e) {
     switch (e.type) {
     case EVENT_CMD_0:
         enter_state(STATE_OFF);
@@ -56,7 +58,7 @@ static void handle_off(fsm_event_t e) {
     }
 }
 
-static void handle_blink_slow(fsm_event_t e) {
+static void state_blink_slow(fsm_event_t e) {
     switch (e.type) {
     case EVENT_CMD_0:
         current_state = STATE_OFF;
@@ -76,7 +78,7 @@ static void handle_blink_slow(fsm_event_t e) {
     }
 }
 
-static void handle_blink_fast(fsm_event_t e) {
+static void state_blink_fast(fsm_event_t e) {
     switch (e.type) {
     case EVENT_CMD_0:
         current_state = STATE_OFF;
@@ -96,7 +98,7 @@ static void handle_blink_fast(fsm_event_t e) {
     }
 }
 
-static void handle_error(fsm_event_t e) {
+static void state_error(fsm_event_t e) {
     switch (e.type) {
     case EVENT_CMD_0:
         current_state = STATE_OFF;
@@ -117,5 +119,5 @@ static void handle_error(fsm_event_t e) {
 }
 
 void fsm_handle_event(fsm_event_t event) {
-    handlers[current_state](event);
+    state_handlers[current_state](event);
 }

--- a/freertos-labs/06_fsm_variants/function_pointer/main.c
+++ b/freertos-labs/06_fsm_variants/function_pointer/main.c
@@ -75,18 +75,24 @@ static void led_task(void *args)
     }
 }
 
+static char recv_char(void)
+{
+    while (!usart_get_flag(USART1, USART_SR_RXNE))
+        taskYIELD();
+    return usart_recv(USART1);
+}
+
 static void fsm_task(void *args) {
     (void)args;
-    const char seq[] = {'1','2','0','x','\0'};
     fsm_reset();
-    for (int i = 0; seq[i] != '\0'; ++i) {
+    send_line("FSM ready");
+    while (1) {
+        char c = recv_char();
         char buf[16];
-        snprintf(buf, sizeof(buf), "Input: %c", seq[i]);
+        snprintf(buf, sizeof(buf), "Input: %c", c);
         send_line(buf);
-        fsm_handle_event(event_from_char(seq[i]));
-        vTaskDelay(pdMS_TO_TICKS(500));
+        fsm_handle_event(event_from_char(c));
     }
-    while (1) vTaskDelay(pdMS_TO_TICKS(1000));
 }
 
 int main(void) {

--- a/freertos-labs/06_fsm_variants/tests/Makefile
+++ b/freertos-labs/06_fsm_variants/tests/Makefile
@@ -1,9 +1,9 @@
 CC=gcc
 UNITY_DIR=../../../tests/unity
 STUB_DIR=../../../tests/stubs
-CFLAGS=-I$(UNITY_DIR) -I$(STUB_DIR) -I../include -std=c99 -Wall -Wextra -DUNIT_TEST
+CFLAGS=-I$(UNITY_DIR) -I$(STUB_DIR) -I../include -std=c99 -Wall -Wextra -g -DUNIT_TEST
 
-TESTS=test_switch_case test_func_pointer test_transition_table test_state_pattern
+TESTS=test_switch_case test_function_pointer test_transition_table test_state_pattern
 OBJS=$(addsuffix .o,$(TESTS)) $(UNITY_DIR)/unity.o \
     $(STUB_DIR)/freertos_stubs.o $(STUB_DIR)/libopencm3_stubs.o
 EXES=$(addsuffix _runner,$(TESTS))

--- a/freertos-labs/06_fsm_variants/tests/test_function_pointer.c
+++ b/freertos-labs/06_fsm_variants/tests/test_function_pointer.c
@@ -1,12 +1,12 @@
 #include "../../tests/unity/unity.h"
 #include "../include/fsm.h"
 
-#include "../func_pointer/fsm_func_pointer.c"
+#include "../function_pointer/fsm_function_pointer.c"
 
 void setUp(void) { fsm_reset(); }
 void tearDown(void) {}
 
-void test_func_pointer(void) {
+void test_function_pointer(void) {
     fsm_handle_event((fsm_event_t){EVENT_CMD_1});
     TEST_ASSERT_EQUAL_INT(STATE_BLINK_SLOW, fsm_get_state());
     fsm_handle_event((fsm_event_t){EVENT_CMD_2});
@@ -19,6 +19,6 @@ void test_func_pointer(void) {
 
 int main(void) {
     UNITY_BEGIN();
-    RUN_TEST(test_func_pointer);
+    RUN_TEST(test_function_pointer);
     return UNITY_END();
 }

--- a/freertos-labs/06_fsm_variants/tests/test_state_pattern.c
+++ b/freertos-labs/06_fsm_variants/tests/test_state_pattern.c
@@ -7,6 +7,7 @@ void setUp(void) { fsm_reset(); }
 void tearDown(void) {}
 
 void test_state_pattern(void) {
+    fsm_reset();
     fsm_handle_event((fsm_event_t){EVENT_CMD_1});
     TEST_ASSERT_EQUAL_INT(STATE_BLINK_SLOW, fsm_get_state());
     fsm_handle_event((fsm_event_t){EVENT_CMD_2});


### PR DESCRIPTION
## Summary
- rename former `state_pattern` example to `function_pointer`
- drop old `func_pointer` directory
- implement proper state pattern variant using state structs
- update tests and docs

## Testing
- `make clean && make -j$(nproc)` in `freertos-labs/06_fsm_variants/tests`
- `./test_switch_case_runner && ./test_function_pointer_runner && ./test_transition_table_runner && ./test_state_pattern_runner`


------
https://chatgpt.com/codex/tasks/task_e_684a11b102fc8323b1015cde2526cf09